### PR TITLE
Call fully qualified date on Darwin

### DIFF
--- a/assume-aws-sso-role
+++ b/assume-aws-sso-role
@@ -47,7 +47,7 @@ iso_8601_to_rfc_822_date() {
 
 date_to_seconds() {
   if [ "${platform}" = Darwin ]; then
-    date -j -f "%FT%T%z" "$(iso_8601_to_rfc_822_date "$1")" "+%s"
+    /bin/date -j -f "%FT%T%z" "$(iso_8601_to_rfc_822_date "$1")" "+%s"
   else
     date -d "$1" "+%s" 2>/dev/null || gdate -d "$expiration" "+%s"
   fi
@@ -55,7 +55,7 @@ date_to_seconds() {
 
 local_time_for() {
   if [ "${platform}" = Darwin ]; then
-    date -j -f "%FT%T%z" "$(iso_8601_to_rfc_822_date "$1")"
+    /bin/date -j -f "%FT%T%z" "$(iso_8601_to_rfc_822_date "$1")"
   else
     date -d "$1"
   fi


### PR DESCRIPTION
When GNU coreutils are installed and in the users $PATH, using `date` unqualified will lead to errors, as -j is an invalid option.